### PR TITLE
Improve parsing of command options

### DIFF
--- a/command_attr/src/impl_hook.rs
+++ b/command_attr/src/impl_hook.rs
@@ -60,7 +60,7 @@ pub fn impl_hook(attr: TokenStream, input: TokenStream) -> Result<TokenStream> {
         }
     };
 
-    Ok(result.into())
+    Ok(result)
 }
 
 fn add_fut_lifetime(generics: &mut Generics) {

--- a/command_attr/src/impl_hook.rs
+++ b/command_attr/src/impl_hook.rs
@@ -1,8 +1,6 @@
-use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream};
 
-use proc_macro2::{Span, TokenStream as TokenStream2};
-
-use syn::parse;
+use syn::parse2;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{Error, FnArg, GenericParam, Generics, ItemFn, Lifetime};
@@ -12,14 +10,13 @@ use quote::quote;
 
 pub fn impl_hook(attr: TokenStream, input: TokenStream) -> Result<TokenStream> {
     if !attr.is_empty() {
-        let attr = TokenStream2::from(attr);
         return Err(Error::new(
             attr.span(),
             "parameters to the `#[hook]` macro are ignored",
         ));
     }
 
-    let fun = parse::<ItemFn>(input)?;
+    let fun = parse2::<ItemFn>(input)?;
 
     let ItemFn {
         attrs,

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -10,16 +10,16 @@ use impl_hook::impl_hook;
 
 #[proc_macro_attribute]
 pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
-    match impl_command(attr, input) {
-        Ok(stream) => stream,
+    match impl_command(attr.into(), input.into()) {
+        Ok(stream) => stream.into(),
         Err(err) => err.to_compile_error().into(),
     }
 }
 
 #[proc_macro_attribute]
 pub fn hook(attr: TokenStream, input: TokenStream) -> TokenStream {
-    match impl_hook(attr, input) {
-        Ok(stream) => stream,
+    match impl_hook(attr.into(), input.into()) {
+        Ok(stream) => stream.into(),
         Err(err) => err.to_compile_error().into(),
     }
 }


### PR DESCRIPTION
With this, any attribute that is not recognised as an option of the `#[command]` attribute is considered external. This avoids checking twice if an attribute is a command option and filtering attributes early.

Support for `/// This is the ping command` descriptions is also added.