### PR TITLE
Append if the `description` builder method is called many times

### DIFF
--- a/framework/src/command.rs
+++ b/framework/src/command.rs
@@ -227,7 +227,14 @@ impl<D, E> CommandBuilder<D, E> {
     where
         I: Into<String>,
     {
-        self.inner.description = Some(description.into());
+        let desc = self.inner.description.get_or_insert_with(String::new);
+
+        if !desc.is_empty() {
+            desc.push('\n');
+        }
+
+        desc.push_str(&description.into());
+
         self
     }
 


### PR DESCRIPTION
This fixes the behaviour of multiline `/// This is a description` command descriptions, so that calling `CommandBuilder::description` will append to the description rather than overriding it with the last call.