### PR TITLE
Remove custom errors

### DIFF
--- a/command_attr/src/impl_check/mod.rs
+++ b/command_attr/src/impl_check/mod.rs
@@ -19,10 +19,10 @@ pub fn impl_check(attr: TokenStream, input: TokenStream) -> Result<TokenStream> 
         parse2::<syn::LitStr>(attr)?.value()
     };
 
-    let (_, data, error) = utils::parse_generics(&fun.sig)?;
+    let (_, data) = utils::parse_generics(&fun.sig)?;
     let options = Options::parse(&mut fun.attrs)?;
 
-    let builder_fn = builder_fn(&data, &error, &mut fun, &name, &options);
+    let builder_fn = builder_fn(&data, &mut fun, &name, &options);
 
     let hook_macro = paths::hook_macro();
 
@@ -37,13 +37,7 @@ pub fn impl_check(attr: TokenStream, input: TokenStream) -> Result<TokenStream> 
     Ok(result)
 }
 
-fn builder_fn(
-    data: &Type,
-    error: &Type,
-    function: &mut ItemFn,
-    name: &str,
-    options: &Options,
-) -> TokenStream {
+fn builder_fn(data: &Type, function: &mut ItemFn, name: &str, options: &Options) -> TokenStream {
     // Derive the name of the builder from the check function.
     // Prepend the check function's name with an underscore to avoid name
     // collisions.
@@ -52,7 +46,7 @@ fn builder_fn(
     function.sig.ident = function_name.clone();
 
     let check_builder = paths::check_builder_type();
-    let check = paths::check_type(data, error);
+    let check = paths::check_type(data);
 
     let vis = &function.vis;
     let external = &function.attrs;

--- a/command_attr/src/impl_command/mod.rs
+++ b/command_attr/src/impl_command/mod.rs
@@ -18,12 +18,12 @@ pub fn impl_command(attr: TokenStream, input: TokenStream) -> Result<TokenStream
         parse2::<AttributeArgs>(attr)?.0
     };
 
-    let (ctx_name, data, error) = utils::parse_generics(&fun.sig)?;
+    let (ctx_name, data) = utils::parse_generics(&fun.sig)?;
     let options = Options::parse(&mut fun.attrs)?;
 
     parse_arguments(ctx_name, &mut fun, &options)?;
 
-    let builder_fn = builder_fn(&data, &error, &mut fun, names, &options);
+    let builder_fn = builder_fn(&data, &mut fun, names, &options);
 
     let hook_macro = paths::hook_macro();
 
@@ -40,7 +40,6 @@ pub fn impl_command(attr: TokenStream, input: TokenStream) -> Result<TokenStream
 
 fn builder_fn(
     data: &Type,
-    error: &Type,
     function: &mut ItemFn,
     mut names: Vec<String>,
     options: &Options,
@@ -56,7 +55,7 @@ fn builder_fn(
     function.sig.ident = function_name.clone();
 
     let command_builder = paths::command_builder_type();
-    let command = paths::command_type(data, error);
+    let command = paths::command_type(data);
 
     let vis = &function.vis;
     let external = &function.attrs;

--- a/command_attr/src/paths.rs
+++ b/command_attr/src/paths.rs
@@ -16,15 +16,9 @@ pub fn default_data_type() -> Box<Type> {
     })
 }
 
-pub fn default_error_type() -> Box<Type> {
-    to_type(quote! {
-        serenity_framework::DefaultError
-    })
-}
-
-pub fn command_type(data: &Type, error: &Type) -> Path {
+pub fn command_type(data: &Type) -> Path {
     to_path(quote! {
-        serenity_framework::command::Command<#data, #error>
+        serenity_framework::command::Command<#data>
     })
 }
 
@@ -64,9 +58,9 @@ pub fn variadic_arguments_func() -> Path {
     })
 }
 
-pub fn check_type(data: &Type, error: &Type) -> Path {
+pub fn check_type(data: &Type) -> Path {
     to_path(quote! {
-        serenity_framework::check::Check<#data, #error>
+        serenity_framework::check::Check<#data>
     })
 }
 

--- a/command_attr/src/utils.rs
+++ b/command_attr/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::paths::{default_data_type, default_error_type};
+use crate::paths::default_data_type;
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
@@ -160,14 +160,13 @@ pub fn parse_bool(attr: &Attr) -> Result<bool> {
     })
 }
 
-pub fn parse_generics(sig: &Signature) -> Result<(Ident, Box<Type>, Box<Type>)> {
+pub fn parse_generics(sig: &Signature) -> Result<(Ident, Box<Type>)> {
     let ctx = get_first_parameter(sig)?;
     let (ident, ty) = get_ident_and_type(ctx)?;
     let path = get_path(&ty)?;
     let mut arguments = get_generic_arguments(path)?;
 
     let default_data = default_data_type();
-    let default_error = default_error_type();
 
     let data = match arguments.next() {
         Some(GenericArgument::Lifetime(_)) => match arguments.next() {
@@ -178,12 +177,7 @@ pub fn parse_generics(sig: &Signature) -> Result<(Ident, Box<Type>, Box<Type>)> 
         None => default_data,
     };
 
-    let error = match arguments.next() {
-        Some(arg) => get_generic_type(arg)?,
-        None => default_error,
-    };
-
-    Ok((ident, data, error))
+    Ok((ident, data))
 }
 
 fn get_first_parameter(sig: &Signature) -> Result<&FnArg> {

--- a/framework/src/check.rs
+++ b/framework/src/check.rs
@@ -8,7 +8,7 @@
 //! [command]: crate::command
 
 use crate::context::CheckContext;
-use crate::{DefaultData, DefaultError};
+use crate::DefaultData;
 
 use serenity::futures::future::BoxFuture;
 use serenity::model::channel::Message;
@@ -59,11 +59,11 @@ impl StdError for Reason {}
 pub type CheckResult<T = ()> = std::result::Result<T, Reason>;
 
 /// The definition of a check function.
-pub type CheckFn<D = DefaultData, E = DefaultError> =
-    for<'fut> fn(&'fut CheckContext<'_, D, E>, &'fut Message) -> BoxFuture<'fut, CheckResult<()>>;
+pub type CheckFn<D = DefaultData> =
+    for<'fut> fn(&'fut CheckContext<'_, D>, &'fut Message) -> BoxFuture<'fut, CheckResult<()>>;
 
 /// A constructor of the [`Check`] type provided by the consumer of the framework.
-pub type CheckConstructor<D = DefaultData, E = DefaultError> = fn() -> Check<D, E>;
+pub type CheckConstructor<D = DefaultData> = fn() -> Check<D>;
 
 /// Data relating to a check.
 ///
@@ -71,20 +71,20 @@ pub type CheckConstructor<D = DefaultData, E = DefaultError> = fn() -> Check<D, 
 ///
 /// [docs]: crate::check
 #[non_exhaustive]
-pub struct Check<D = DefaultData, E = DefaultError> {
+pub struct Check<D = DefaultData> {
     /// Name of the check.
     ///
     /// Used in help commands.
     pub name: String,
     /// The function of this check.
-    pub function: CheckFn<D, E>,
+    pub function: CheckFn<D>,
     /// A boolean indicating whether the check can apply in help commands.
     pub check_in_help: bool,
     /// A boolean indicating whether the check can be displayed in help commands.
     pub display_in_help: bool,
 }
 
-impl<D, E> Clone for Check<D, E> {
+impl<D> Clone for Check<D> {
     fn clone(&self) -> Self {
         Self {
             name: self.name.clone(),
@@ -95,7 +95,7 @@ impl<D, E> Clone for Check<D, E> {
     }
 }
 
-impl<D, E> Default for Check<D, E> {
+impl<D> Default for Check<D> {
     fn default() -> Self {
         Self {
             name: String::default(),
@@ -106,7 +106,7 @@ impl<D, E> Default for Check<D, E> {
     }
 }
 
-impl<D, E> fmt::Debug for Check<D, E> {
+impl<D> fmt::Debug for Check<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Check")
             .field("name", &self.name)
@@ -117,11 +117,11 @@ impl<D, E> fmt::Debug for Check<D, E> {
     }
 }
 
-impl<D, E> Check<D, E> {
+impl<D> Check<D> {
     /// Constructs a builder that will be used to create a check from scratch.
     ///
     /// Argument is the main name of the check.
-    pub fn builder<I>(name: I) -> CheckBuilder<D, E>
+    pub fn builder<I>(name: I) -> CheckBuilder<D>
     where
         I: Into<String>,
     {
@@ -130,11 +130,11 @@ impl<D, E> Check<D, E> {
 }
 
 /// A builder type for creating a [`Check`] from scratch.
-pub struct CheckBuilder<D, E> {
-    inner: Check<D, E>,
+pub struct CheckBuilder<D> {
+    inner: Check<D>,
 }
 
-impl<D, E> CheckBuilder<D, E> {
+impl<D> CheckBuilder<D> {
     /// Constructs a new instance of the builder.
     ///
     /// Argument is the main name of the check.
@@ -150,7 +150,7 @@ impl<D, E> CheckBuilder<D, E> {
         }
     }
     /// Assigns the function to this function.
-    pub fn function(mut self, function: CheckFn<D, E>) -> Self {
+    pub fn function(mut self, function: CheckFn<D>) -> Self {
         self.inner.function = function;
         self
     }
@@ -168,12 +168,12 @@ impl<D, E> CheckBuilder<D, E> {
     }
 
     /// Complete building a check.
-    pub fn build(self) -> Check<D, E> {
+    pub fn build(self) -> Check<D> {
         self.inner
     }
 }
 
-impl<D, E> Clone for CheckBuilder<D, E> {
+impl<D> Clone for CheckBuilder<D> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -181,7 +181,7 @@ impl<D, E> Clone for CheckBuilder<D, E> {
     }
 }
 
-impl<D, E> Default for CheckBuilder<D, E> {
+impl<D> Default for CheckBuilder<D> {
     fn default() -> Self {
         Self {
             inner: Check::default(),
@@ -189,7 +189,7 @@ impl<D, E> Default for CheckBuilder<D, E> {
     }
 }
 
-impl<D, E> fmt::Debug for CheckBuilder<D, E> {
+impl<D> fmt::Debug for CheckBuilder<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CheckBuilder")
             .field("inner", &self.inner)

--- a/framework/src/configuration.rs
+++ b/framework/src/configuration.rs
@@ -3,7 +3,7 @@
 use crate::category::Category;
 use crate::command::{CommandConstructor, CommandId, CommandMap};
 use crate::context::PrefixContext;
-use crate::{DefaultData, DefaultError};
+use crate::DefaultData;
 
 use serenity::futures::future::BoxFuture;
 use serenity::model::channel::Message;
@@ -12,16 +12,16 @@ use serenity::model::id::UserId;
 use std::fmt;
 
 /// The definition of the dynamic prefix hook.
-pub type DynamicPrefix<D, E> =
-    for<'a> fn(ctx: PrefixContext<'_, D, E>, msg: &'a Message) -> BoxFuture<'a, Option<usize>>;
+pub type DynamicPrefix<D> =
+    for<'a> fn(ctx: PrefixContext<'_, D>, msg: &'a Message) -> BoxFuture<'a, Option<usize>>;
 
 /// The configuration of the framework.
 #[non_exhaustive]
-pub struct Configuration<D = DefaultData, E = DefaultError> {
+pub struct Configuration<D = DefaultData> {
     /// A list of static prefixes.
     pub prefixes: Vec<String>,
     /// A function to dynamically parse the prefix.
-    pub dynamic_prefix: Option<DynamicPrefix<D, E>>,
+    pub dynamic_prefix: Option<DynamicPrefix<D>>,
     /// A boolean indicating whether casing of the letters in static prefixes,
     /// or command names does not matter.
     pub case_insensitive: bool,
@@ -39,10 +39,10 @@ pub struct Configuration<D = DefaultData, E = DefaultError> {
     ///
     /// [`IdMap`]: crate::utils::IdMap
     /// [`Command`]: crate::command::Command
-    pub commands: CommandMap<D, E>,
+    pub commands: CommandMap<D>,
 }
 
-impl<D, E> Clone for Configuration<D, E> {
+impl<D> Clone for Configuration<D> {
     fn clone(&self) -> Self {
         Self {
             prefixes: self.prefixes.clone(),
@@ -56,7 +56,7 @@ impl<D, E> Clone for Configuration<D, E> {
     }
 }
 
-impl<D, E> Default for Configuration<D, E> {
+impl<D> Default for Configuration<D> {
     fn default() -> Self {
         Self {
             prefixes: Vec::default(),
@@ -70,7 +70,7 @@ impl<D, E> Default for Configuration<D, E> {
     }
 }
 
-impl<D, E> Configuration<D, E> {
+impl<D> Configuration<D> {
     /// Creates a new instance of the framework configuration.
     pub fn new() -> Self {
         Self::default()
@@ -90,7 +90,7 @@ impl<D, E> Configuration<D, E> {
     }
 
     /// Assigns a function to dynamically parse the prefix.
-    pub fn dynamic_prefix(&mut self, prefix: DynamicPrefix<D, E>) -> &mut Self {
+    pub fn dynamic_prefix(&mut self, prefix: DynamicPrefix<D>) -> &mut Self {
         self.dynamic_prefix = Some(prefix);
         self
     }
@@ -127,7 +127,7 @@ impl<D, E> Configuration<D, E> {
     /// [`categories`]: Self::categories
     /// [`commands`]: Self::commands
     /// [cmd]: Self::command
-    pub fn category<I>(&mut self, name: I, cmds: &[CommandConstructor<D, E>]) -> &mut Self
+    pub fn category<I>(&mut self, name: I, cmds: &[CommandConstructor<D>]) -> &mut Self
     where
         I: Into<String>,
     {
@@ -151,7 +151,7 @@ impl<D, E> Configuration<D, E> {
     /// The command is added to the [`commands`] map.
     ///
     /// [`commands`]: Self::commands
-    pub fn command(&mut self, command: CommandConstructor<D, E>) -> &mut Self {
+    pub fn command(&mut self, command: CommandConstructor<D>) -> &mut Self {
         let id = CommandId::from(command);
 
         // Avoid instantiating the command if the map already contains it.
@@ -173,7 +173,7 @@ impl<D, E> Configuration<D, E> {
         }
 
         for id in &command.subcommands {
-            let ctor: CommandConstructor<D, E> = id.into_constructor();
+            let ctor: CommandConstructor<D> = id.into_constructor();
             self.command(ctor);
         }
 
@@ -183,7 +183,7 @@ impl<D, E> Configuration<D, E> {
     }
 }
 
-impl<D, E> fmt::Debug for Configuration<D, E> {
+impl<D> fmt::Debug for Configuration<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Configuration")
             .field("prefixes", &self.prefixes)

--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -9,7 +9,7 @@
 
 use crate::command::CommandId;
 use crate::configuration::Configuration;
-use crate::{DefaultData, DefaultError};
+use crate::DefaultData;
 
 use serenity::cache::Cache;
 use serenity::client::Context as SerenityContext;
@@ -27,11 +27,11 @@ use std::sync::Arc;
 ///
 /// [ctx]: crate::command::CommandFn
 #[non_exhaustive]
-pub struct Context<D = DefaultData, E = DefaultError> {
+pub struct Context<D = DefaultData> {
     /// User data.
     pub data: Arc<RwLock<D>>,
     /// Framework configuration.
-    pub conf: Arc<Mutex<Configuration<D, E>>>,
+    pub conf: Arc<Mutex<Configuration<D>>>,
     /// Serenity's context type.
     pub serenity_ctx: SerenityContext,
     /// The identifier of the command.
@@ -46,7 +46,7 @@ pub struct Context<D = DefaultData, E = DefaultError> {
     pub args: String,
 }
 
-impl<D, E> Clone for Context<D, E> {
+impl<D> Clone for Context<D> {
     fn clone(&self) -> Self {
         Self {
             data: Arc::clone(&self.data),
@@ -59,22 +59,21 @@ impl<D, E> Clone for Context<D, E> {
     }
 }
 
-impl<D, E> AsRef<Http> for Context<D, E> {
+impl<D> AsRef<Http> for Context<D> {
     fn as_ref(&self) -> &Http {
         &self.serenity_ctx.http
     }
 }
 
-impl<D, E> AsRef<Cache> for Context<D, E> {
+impl<D> AsRef<Cache> for Context<D> {
     fn as_ref(&self) -> &Cache {
         &self.serenity_ctx.cache
     }
 }
 
-impl<D, E> CacheHttp for Context<D, E>
+impl<D> CacheHttp for Context<D>
 where
     D: Send + Sync,
-    E: Send + Sync,
 {
     fn http(&self) -> &Http {
         &self.serenity_ctx.http
@@ -91,16 +90,16 @@ where
 ///
 /// [dyn_prefix]: crate::configuration::DynamicPrefix
 #[non_exhaustive]
-pub struct PrefixContext<'a, D = DefaultData, E = DefaultError> {
+pub struct PrefixContext<'a, D = DefaultData> {
     /// User data.
     pub data: &'a Arc<RwLock<D>>,
     /// Framework configuration.
-    pub conf: &'a Configuration<D, E>,
+    pub conf: &'a Configuration<D>,
     /// Serenity's context type.
     pub serenity_ctx: &'a SerenityContext,
 }
 
-impl<'a, D, E> Clone for PrefixContext<'a, D, E> {
+impl<'a, D> Clone for PrefixContext<'a, D> {
     fn clone(&self) -> Self {
         Self {
             data: self.data,
@@ -110,22 +109,21 @@ impl<'a, D, E> Clone for PrefixContext<'a, D, E> {
     }
 }
 
-impl<D, E> AsRef<Http> for PrefixContext<'_, D, E> {
+impl<D> AsRef<Http> for PrefixContext<'_, D> {
     fn as_ref(&self) -> &Http {
         &self.serenity_ctx.http
     }
 }
 
-impl<D, E> AsRef<Cache> for PrefixContext<'_, D, E> {
+impl<D> AsRef<Cache> for PrefixContext<'_, D> {
     fn as_ref(&self) -> &Cache {
         &self.serenity_ctx.cache
     }
 }
 
-impl<D, E> CacheHttp for PrefixContext<'_, D, E>
+impl<D> CacheHttp for PrefixContext<'_, D>
 where
     D: Send + Sync,
-    E: Send + Sync,
 {
     fn http(&self) -> &Http {
         &self.serenity_ctx.http
@@ -142,18 +140,18 @@ where
 ///
 /// [fn]: crate::check::CheckFn
 #[non_exhaustive]
-pub struct CheckContext<'a, D = DefaultData, E = DefaultError> {
+pub struct CheckContext<'a, D = DefaultData> {
     /// User data.
     pub data: &'a Arc<RwLock<D>>,
     /// Framework configuration.
-    pub conf: &'a Configuration<D, E>,
+    pub conf: &'a Configuration<D>,
     /// Serenity's context type.
     pub serenity_ctx: &'a SerenityContext,
     /// The identifier of the command that is being checked upon.
     pub command_id: CommandId,
 }
 
-impl<'a, D, E> Clone for CheckContext<'a, D, E> {
+impl<'a, D> Clone for CheckContext<'a, D> {
     fn clone(&self) -> Self {
         Self {
             data: self.data,
@@ -164,22 +162,21 @@ impl<'a, D, E> Clone for CheckContext<'a, D, E> {
     }
 }
 
-impl<D, E> AsRef<Http> for CheckContext<'_, D, E> {
+impl<D> AsRef<Http> for CheckContext<'_, D> {
     fn as_ref(&self) -> &Http {
         &self.serenity_ctx.http
     }
 }
 
-impl<D, E> AsRef<Cache> for CheckContext<'_, D, E> {
+impl<D> AsRef<Cache> for CheckContext<'_, D> {
     fn as_ref(&self) -> &Cache {
         &self.serenity_ctx.cache
     }
 }
 
-impl<D, E> CacheHttp for CheckContext<'_, D, E>
+impl<D> CacheHttp for CheckContext<'_, D>
 where
     D: Send + Sync,
-    E: Send + Sync,
 {
     fn http(&self) -> &Http {
         &self.serenity_ctx.http

--- a/framework/src/error.rs
+++ b/framework/src/error.rs
@@ -1,7 +1,7 @@
 //! Defines error types used by the framework.
 
 use crate::check::Reason;
-use crate::DefaultError;
+use crate::command::CommandError;
 
 use std::error::Error as StdError;
 use std::fmt;
@@ -45,21 +45,21 @@ impl StdError for DispatchError {}
 /// Returned when the call of [`dispatch`] fails.
 ///
 /// [`dispatch`]: crate::Framework::dispatch
-#[derive(Debug, Clone)]
-pub enum Error<E = DefaultError> {
+#[derive(Debug)]
+pub enum Error {
     /// Failed to dispatch a command.
     Dispatch(DispatchError),
     /// A command returned an error.
-    User(E),
+    User(CommandError),
 }
 
-impl<E> From<DispatchError> for Error<E> {
+impl From<DispatchError> for Error {
     fn from(e: DispatchError) -> Self {
         Self::Dispatch(e)
     }
 }
 
-impl<E: fmt::Display> fmt::Display for Error<E> {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Dispatch(err) => fmt::Display::fmt(err, f),
@@ -68,11 +68,11 @@ impl<E: fmt::Display> fmt::Display for Error<E> {
     }
 }
 
-impl<E: StdError + 'static> StdError for Error<E> {
+impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             Error::Dispatch(err) => Some(err),
-            Error::User(err) => Some(err),
+            Error::User(err) => Some(&**err),
         }
     }
 }

--- a/framework/src/parse.rs
+++ b/framework/src/parse.rs
@@ -55,8 +55,8 @@ pub fn mention<'a>(msg: &'a str, id: &str) -> Option<(&'a str, &'a str)> {
 ///
 /// [`Configuration::dynamic_prefix`]: crate::configuration::Configuration::dynamic_prefix
 #[allow(clippy::needless_lifetimes)]
-pub async fn dynamic_prefix<'a, D, E>(
-    ctx: PrefixContext<'_, D, E>,
+pub async fn dynamic_prefix<'a, D>(
+    ctx: PrefixContext<'_, D>,
     msg: &'a Message,
 ) -> Option<(&'a str, &'a str)> {
     if let Some(dynamic_prefix) = ctx.conf.dynamic_prefix {
@@ -98,9 +98,9 @@ pub fn static_prefix<'a>(msg: &'a str, prefixes: &[String]) -> Option<(&'a str, 
 /// [prefixes]: static_prefix
 /// [dyn_prefix]: dynamic_prefix
 #[allow(clippy::needless_lifetimes)]
-pub async fn content<'a, D, E>(
+pub async fn content<'a, D>(
     data: &Arc<RwLock<D>>,
-    conf: &Configuration<D, E>,
+    conf: &Configuration<D>,
     serenity_ctx: &SerenityContext,
     msg: &'a Message,
 ) -> Option<(&'a str, &'a str)> {
@@ -134,15 +134,15 @@ pub async fn content<'a, D, E>(
 /// Refer to its documentation for more information.
 ///
 /// [`commands`]: self::commands
-pub struct CommandIterator<'a, 'b, 'c, D, E> {
-    conf: &'a Configuration<D, E>,
+pub struct CommandIterator<'a, 'b, 'c, D> {
+    conf: &'a Configuration<D>,
     segments: &'b mut Segments<'c>,
-    command: Option<&'a Command<D, E>>,
+    command: Option<&'a Command<D>>,
     beginning: bool,
 }
 
-impl<'a, 'b, 'c, D, E> Iterator for CommandIterator<'a, 'b, 'c, D, E> {
-    type Item = Result<&'a Command<D, E>, DispatchError>;
+impl<'a, 'b, 'c, D> Iterator for CommandIterator<'a, 'b, 'c, D> {
+    type Item = Result<&'a Command<D>, DispatchError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let checkpoint = self.segments.source();
@@ -201,10 +201,10 @@ impl<'a, 'b, 'c, D, E> Iterator for CommandIterator<'a, 'b, 'c, D, E> {
 /// [`Command`]: crate::command::Command
 /// [`DispatchError`]: crate::error::DispatchError
 /// [`InvalidCommandName`]: crate::error::DispatchError::InvalidCommandName
-pub fn commands<'a, 'b, 'c, D, E>(
-    conf: &'a Configuration<D, E>,
+pub fn commands<'a, 'b, 'c, D>(
+    conf: &'a Configuration<D>,
     segments: &'b mut Segments<'c>,
-) -> CommandIterator<'a, 'b, 'c, D, E> {
+) -> CommandIterator<'a, 'b, 'c, D> {
     CommandIterator {
         conf,
         segments,


### PR DESCRIPTION
While it seemed like a nice idea, it complicates matters more than just using `Box<dyn std::error::Error>`, which will cover most use cases. If the user wants to handle a specific error, they can downcast if necessary.