### PR TITLE
Remove the `Argument` trait in favour of using `FromStr` directly

### DIFF
--- a/command_attr/src/impl_command/mod.rs
+++ b/command_attr/src/impl_command/mod.rs
@@ -104,7 +104,7 @@ fn parse_arguments(ctx_name: Ident, function: &mut ItemFn, options: &Options) ->
                 // afterwards, as `ArgumentSegments` holds a reference to the source string.
                 let mut __args = #asegsty::new(&#ctx_name.args, #delimiter);
 
-                #(let #argument_names: #argument_tys = #argument_kinds(&#ctx_name, &mut __args)?;)*
+                #(let #argument_names: #argument_tys = #argument_kinds(&mut __args)?;)*
 
                 (#(#argument_names),*)
             };


### PR DESCRIPTION
This removes the trait, which only had a blanket impl for types that implement `FromStr`, thereby making it a proxy. 

The reason for its removal is due to the `Context` parameter. I made the trait for the sole purpose of being able to parse arguments using additional information derived from the context, but this proved to be a bad decision. I was about to implement the trait for `serenity::model::user::User`, `serenity::model::channel::GuildChannel`, `serenity::model::guild::Role`, and so on when I hit a roadblock -- I couldn't implement the trait because the blanket impl prevented me (as those types could later implement `FromStr`, introducing a collision). Not only that, I couldn't use the http client or cache, as their functions need to be `.await`ed. I could've used `#[async_trait]`, but I went against that since it would allocate futures on every `Argument::parse` call.

Thus, I've chosen to remove it and just use `FromStr`. It eliminates the need to implement a new trait and it is something people are going to be familiar with already.