### PR TITLE
Add support for the remainder of arguments

### DIFF
--- a/command_attr/src/paths.rs
+++ b/command_attr/src/paths.rs
@@ -64,6 +64,12 @@ pub fn variadic_arguments_func() -> Path {
     })
 }
 
+pub fn rest_argument_func() -> Path {
+    to_path(quote! {
+        serenity_framework::argument::rest_argument
+    })
+}
+
 pub fn check_type(data: &Type, error: &Type) -> Path {
     to_path(quote! {
         serenity_framework::check::Check<#data, #error>

--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -88,3 +88,16 @@ where
         .map(|seg| T::from_str(seg).map_err(ArgumentError::Argument))
         .collect()
 }
+
+/// Parses the remainder of the list of segments into an argument.
+///
+/// All segments (even if none) are concatenated to a single string
+/// and parsed to the specified argument type. If parsing success,
+/// `Ok(...)` is returned, otherwise `Err(...)`. The error is wrapped in
+/// [`ArgumentError::Argument`].
+pub fn rest_argument<T>(segments: &mut ArgumentSegments<'_>) -> Result<T, ArgumentError<T::Err>>
+where
+    T: FromStr,
+{
+    T::from_str(segments.source()).map_err(ArgumentError::Argument)
+}


### PR DESCRIPTION
This adds a new type of argument called *rest*. This causes the framework to treat the remainder of the arguments passed to the command as a single string and parse an argument out of it. The syntax for declaring a rest argument is by prepending `#[rest]` before the argument parameter.