### PR TITLE
Borrow the Serenity context and message types

### DIFF
--- a/framework/src/command.rs
+++ b/framework/src/command.rs
@@ -43,7 +43,7 @@ pub type CommandResult<T = (), E = DefaultError> = std::result::Result<T, E>;
 
 /// The definition of a command function.
 pub type CommandFn<D = DefaultData, E = DefaultError> =
-    fn(Context<D, E>, Message) -> BoxFuture<'static, CommandResult<(), E>>;
+    for<'a> fn(Context<D, E>, &'a Message) -> BoxFuture<'a, CommandResult<(), E>>;
 
 /// A constructor of the [`Command`] type provided by the consumer of the framework.
 pub type CommandConstructor<D = DefaultData, E = DefaultError> = fn() -> Command<D, E>;


### PR DESCRIPTION
This changes the definition of `Framework::dispatch` to borrow its parameters, rather than consume, to allow for their continued use after the call. This also takes the opportunity to remove the future hook and rename `dispatch_with_hook` to `parse`, leaving actual execution of the command to `dispatch`. 