### PR TITLE
Allow only root commands to appear at the beginning of an invocation 

### DIFF
--- a/framework/src/configuration.rs
+++ b/framework/src/configuration.rs
@@ -171,17 +171,6 @@ impl<D, E> Configuration<D, E> {
         self
     }
 
-    fn _subcommand(&mut self, command: CommandConstructor<D, E>) {
-        let id = CommandId::from(command);
-
-        // Skip instantiating this subcommand if it already exists.
-        if self.commands.contains_id(id) {
-            return;
-        }
-
-        self._command(id, command);
-    }
-
     fn _command(&mut self, id: CommandId, command: CommandConstructor<D, E>) {
         let mut command = command();
         command.id = id;
@@ -197,8 +186,13 @@ impl<D, E> Configuration<D, E> {
         }
 
         for id in &command.subcommands {
+            // Skip instantiating this subcommand if it already exists.
+            if self.commands.contains_id(*id) {
+                continue;
+            }
+
             let ctor: CommandConstructor<D, E> = id.into_constructor();
-            self._subcommand(ctor);
+            self._command(*id, ctor);
         }
 
         self.commands.insert(command.id, command);

--- a/framework/src/configuration.rs
+++ b/framework/src/configuration.rs
@@ -9,6 +9,7 @@ use serenity::futures::future::BoxFuture;
 use serenity::model::channel::Message;
 use serenity::model::id::UserId;
 
+use std::collections::HashSet;
 use std::fmt;
 
 /// The definition of the dynamic prefix hook.
@@ -35,6 +36,8 @@ pub struct Configuration<D = DefaultData, E = DefaultError> {
     ///
     /// [`Category`]: crate::category::Category
     pub categories: Vec<Category>,
+    /// A set of commands that can only appear at the beginning of a command invocation.
+    pub root_level_commands: HashSet<CommandId>,
     /// An [`IdMap`] containing all [`Command`]s.
     ///
     /// [`IdMap`]: crate::utils::IdMap
@@ -51,6 +54,7 @@ impl<D, E> Clone for Configuration<D, E> {
             no_dm_prefix: self.no_dm_prefix,
             on_mention: self.on_mention.clone(),
             categories: self.categories.clone(),
+            root_level_commands: self.root_level_commands.clone(),
             commands: self.commands.clone(),
         }
     }
@@ -65,6 +69,7 @@ impl<D, E> Default for Configuration<D, E> {
             no_dm_prefix: false,
             on_mention: None,
             categories: Vec::default(),
+            root_level_commands: HashSet::default(),
             commands: CommandMap::default(),
         }
     }
@@ -148,17 +153,36 @@ impl<D, E> Configuration<D, E> {
 
     /// Assigns a command to this configuration.
     ///
-    /// The command is added to the [`commands`] map.
+    /// The command is added to the [`commands`] map, alongside its subcommands.
+    /// It it also added into the [`root_level_commands`] set.
     ///
     /// [`commands`]: Self::commands
+    /// [`root_level_commands`]: Self::root_level_commands
     pub fn command(&mut self, command: CommandConstructor<D, E>) -> &mut Self {
         let id = CommandId::from(command);
 
-        // Avoid instantiating the command if the map already contains it.
-        if self.commands.contains_id(id) {
+        // Skip instantiating this root command if if already exists.
+        if self.root_level_commands.contains(&id) {
             return self;
         }
 
+        self.root_level_commands.insert(id);
+        self._command(id, command);
+        self
+    }
+
+    fn _subcommand(&mut self, command: CommandConstructor<D, E>) {
+        let id = CommandId::from(command);
+
+        // Skip instantiating this subcommand if it already exists.
+        if self.commands.contains_id(id) {
+            return;
+        }
+
+        self._command(id, command);
+    }
+
+    fn _command(&mut self, id: CommandId, command: CommandConstructor<D, E>) {
         let mut command = command();
         command.id = id;
 
@@ -174,12 +198,10 @@ impl<D, E> Configuration<D, E> {
 
         for id in &command.subcommands {
             let ctor: CommandConstructor<D, E> = id.into_constructor();
-            self.command(ctor);
+            self._subcommand(ctor);
         }
 
         self.commands.insert(command.id, command);
-
-        self
     }
 }
 
@@ -192,6 +214,7 @@ impl<D, E> fmt::Debug for Configuration<D, E> {
             .field("no_dm_prefix", &self.no_dm_prefix)
             .field("on_mention", &self.on_mention)
             .field("categories", &self.categories)
+            .field("root_level_commands", &self.root_level_commands)
             .field("commands", &self.commands)
             .finish()
     }

--- a/framework/src/parse.rs
+++ b/framework/src/parse.rs
@@ -138,7 +138,6 @@ pub struct CommandIterator<'a, 'b, 'c, D, E> {
     conf: &'a Configuration<D, E>,
     segments: &'b mut Segments<'c>,
     command: Option<&'a Command<D, E>>,
-    beginning: bool,
 }
 
 impl<'a, 'b, 'c, D, E> Iterator for CommandIterator<'a, 'b, 'c, D, E> {
@@ -156,7 +155,7 @@ impl<'a, 'b, 'c, D, E> Iterator for CommandIterator<'a, 'b, 'c, D, E> {
                 // At least one valid command must be present in the message.
                 // After the first command, we do not care if the "name" is invalid,
                 // as it may be the argument to the command at that point.
-                if self.beginning {
+                if self.command.is_none() {
                     return Some(Err(DispatchError::InvalidCommandName(name.into_owned())));
                 }
 
@@ -164,7 +163,7 @@ impl<'a, 'b, 'c, D, E> Iterator for CommandIterator<'a, 'b, 'c, D, E> {
             },
         };
 
-        if self.beginning && !self.conf.root_level_commands.contains(&cmd.id) {
+        if self.command.is_none() && !self.conf.root_level_commands.contains(&cmd.id) {
             self.segments.set_source(checkpoint);
             return None;
         }
@@ -181,7 +180,6 @@ impl<'a, 'b, 'c, D, E> Iterator for CommandIterator<'a, 'b, 'c, D, E> {
         }
 
         self.command = Some(cmd);
-        self.beginning = false;
 
         Some(Ok(cmd))
     }
@@ -214,6 +212,5 @@ pub fn commands<'a, 'b, 'c, D, E>(
         conf,
         segments,
         command: None,
-        beginning: true,
     }
 }

--- a/framework/src/parse.rs
+++ b/framework/src/parse.rs
@@ -164,6 +164,11 @@ impl<'a, 'b, 'c, D, E> Iterator for CommandIterator<'a, 'b, 'c, D, E> {
             },
         };
 
+        if self.beginning && !self.conf.root_level_commands.contains(&cmd.id) {
+            self.segments.set_source(checkpoint);
+            return None;
+        }
+
         if let Some(command) = self.command {
             if !command.subcommands.contains(&cmd.id) {
                 // We received a command, but it's not a subcommand of the previously


### PR DESCRIPTION
This prevents invoking a command that is only a subcommand of another, and shouldn't be invocable by itself.