### PR TITLE
Remove `RwLock` from the data definition

### DIFF
--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use serenity::cache::Cache;
 use serenity::client::Context as SerenityContext;
 use serenity::http::{CacheHttp, Http};
-use serenity::prelude::{Mutex, RwLock};
+use serenity::prelude::Mutex;
 
 use crate::command::CommandId;
 use crate::configuration::Configuration;
@@ -29,7 +29,7 @@ use crate::{DefaultData, DefaultError};
 #[non_exhaustive]
 pub struct Context<D = DefaultData, E = DefaultError> {
     /// User data.
-    pub data: Arc<RwLock<D>>,
+    pub data: Arc<D>,
     /// Framework configuration.
     pub conf: Arc<Mutex<Configuration<D, E>>>,
     /// Serenity's context type.
@@ -93,7 +93,7 @@ where
 #[non_exhaustive]
 pub struct PrefixContext<'a, D = DefaultData, E = DefaultError> {
     /// User data.
-    pub data: &'a Arc<RwLock<D>>,
+    pub data: &'a Arc<D>,
     /// Framework configuration.
     pub conf: &'a Configuration<D, E>,
     /// Serenity's context type.
@@ -144,7 +144,7 @@ where
 #[non_exhaustive]
 pub struct CheckContext<'a, D = DefaultData, E = DefaultError> {
     /// User data.
-    pub data: &'a Arc<RwLock<D>>,
+    pub data: &'a Arc<D>,
     /// Framework configuration.
     pub conf: &'a Configuration<D, E>,
     /// Serenity's context type.

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -40,7 +40,7 @@ use std::error::Error as StdError;
 use std::sync::Arc;
 
 use serenity::model::channel::Message;
-use serenity::prelude::{Context as SerenityContext, Mutex, RwLock};
+use serenity::prelude::{Context as SerenityContext, Mutex};
 
 pub mod argument;
 pub mod category;
@@ -75,7 +75,7 @@ pub struct Framework<D = DefaultData, E = DefaultError> {
     /// Configuration of the framework that dictates its behaviour.
     pub conf: Arc<Mutex<Configuration<D, E>>>,
     /// User data that is accessable in every command and function hook.
-    pub data: Arc<RwLock<D>>,
+    pub data: Arc<D>,
 }
 
 impl<D, E> Framework<D, E>
@@ -106,12 +106,12 @@ impl<D, E> Framework<D, E> {
     /// [`with_arc_data`]: Self::with_arc_data
     #[inline]
     pub fn with_data(conf: Configuration<D, E>, data: D) -> Self {
-        Self::with_arc_data(conf, Arc::new(RwLock::new(data)))
+        Self::with_arc_data(conf, Arc::new(data))
     }
 
     /// Creates new instanstiation of the framework using a given configuration and data.
     #[inline]
-    pub fn with_arc_data(conf: Configuration<D, E>, data: Arc<RwLock<D>>) -> Self {
+    pub fn with_arc_data(conf: Configuration<D, E>, data: Arc<D>) -> Self {
         Self {
             conf: Arc::new(Mutex::new(conf)),
             data,

--- a/framework/src/parse.rs
+++ b/framework/src/parse.rs
@@ -96,7 +96,7 @@ pub fn static_prefix<'a>(msg: &'a str, prefixes: &[String]) -> Option<(&'a str, 
 /// [dyn_prefix]: dynamic_prefix
 #[allow(clippy::needless_lifetimes)]
 pub async fn content<'a, D, E>(
-    data: &Arc<RwLock<D>>,
+    data: &Arc<D>,
     conf: &Configuration<D, E>,
     serenity_ctx: &SerenityContext,
     msg: &'a Message,

--- a/framework/src/parse.rs
+++ b/framework/src/parse.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use serenity::client::Context as SerenityContext;
 use serenity::model::channel::Message;
-use serenity::prelude::RwLock;
 
 use crate::command::Command;
 use crate::configuration::Configuration;


### PR DESCRIPTION
## Description

This removes the `RwLock` wrapper type from the definition of the `Framework::data` field, leaving interior mutability a responsibility to the user. This allows to read parts of the data directly, and if modification is needed, the user can decide to cover the data in `Mutex` or `RwLock`. 

## Type of Change

This changes the type definition in the public API, making this a breaking change. It resolves #22.

## How Has This Been Tested?

This has been tested on a personal test bot for the new framework. By adjusting usage of data, it is still possible to read it, and via `Mutex` or `RwLock` mutate it.
