### PR TITLE
Use Parse trait for parameter parsing

### DIFF
--- a/command_attr/src/impl_check/mod.rs
+++ b/command_attr/src/impl_check/mod.rs
@@ -19,7 +19,7 @@ pub fn impl_check(attr: TokenStream, input: TokenStream) -> Result<TokenStream> 
         parse2::<syn::LitStr>(attr)?.value()
     };
 
-    let (_, data, error) = utils::parse_generics(&fun.sig)?;
+    let (_, _, data, error) = utils::parse_generics(&fun.sig)?;
     let options = Options::parse(&mut fun.attrs)?;
 
     let builder_fn = builder_fn(&data, &error, &mut fun, &name, &options);

--- a/command_attr/src/paths.rs
+++ b/command_attr/src/paths.rs
@@ -46,27 +46,51 @@ pub fn argument_segments_type() -> Path {
     })
 }
 
-pub fn required_argument_func() -> Path {
+pub fn required_argument_from_str_func() -> Path {
     to_path(quote! {
-        serenity_framework::argument::required_argument
+        serenity_framework::argument::required_argument_from_str
     })
 }
 
-pub fn optional_argument_func() -> Path {
+pub fn required_argument_parse_func() -> Path {
     to_path(quote! {
-        serenity_framework::argument::optional_argument
+        serenity_framework::argument::required_argument_parse
     })
 }
 
-pub fn variadic_arguments_func() -> Path {
+pub fn optional_argument_from_str_func() -> Path {
     to_path(quote! {
-        serenity_framework::argument::variadic_arguments
+        serenity_framework::argument::optional_argument_from_str
     })
 }
 
-pub fn rest_argument_func() -> Path {
+pub fn optional_argument_parse_func() -> Path {
     to_path(quote! {
-        serenity_framework::argument::rest_argument
+        serenity_framework::argument::optional_argument_parse
+    })
+}
+
+pub fn variadic_arguments_from_str_func() -> Path {
+    to_path(quote! {
+        serenity_framework::argument::variadic_arguments_from_str
+    })
+}
+
+pub fn variadic_arguments_parse_func() -> Path {
+    to_path(quote! {
+        serenity_framework::argument::variadic_arguments_parse
+    })
+}
+
+pub fn rest_argument_from_str_func() -> Path {
+    to_path(quote! {
+        serenity_framework::argument::rest_argument_from_str
+    })
+}
+
+pub fn rest_argument_parse_func() -> Path {
+    to_path(quote! {
+        serenity_framework::argument::rest_argument_parse
     })
 }
 

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Alex M. M. <acdenissk69@gmail.com>"]
 edition = "2018"
 
 [dependencies.serenity]
-git = "https://github.com/kangalioo/serenity" # Replace with main serenity branch once merged
-branch = "parse"
+git = "https://github.com/serenity-rs/serenity"
+branch = "current"
 default_features = false
 features = ["client", "model", "gateway", "cache", "rustls_backend"]
 

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Alex M. M. <acdenissk69@gmail.com>"]
 edition = "2018"
 
 [dependencies.serenity]
-version = "0.10"
+git = "https://github.com/kangalioo/serenity" # Replace with main serenity branch once merged
+branch = "parse"
 default_features = false
 features = ["client", "model", "gateway", "cache", "rustls_backend"]
 

--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -16,7 +16,7 @@ pub enum ArgumentError<E> {
     Missing,
     /// Parsing the argument failed.
     ///
-    /// Contains the error from [`FromStr::Err`].
+    /// Contains the error from [`serenity::utils::Parse::Err`].
     Argument(E),
 }
 

--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -38,14 +38,37 @@ impl<E: StdError + 'static> StdError for ArgumentError<E> {
     }
 }
 
-/// Takes a single segment from a list of segments and parses an argument out of it.
+/// Takes a single segment from a list of segments and parses an argument out of it using the
+/// [std::str::FromStr] trait.
 ///
 /// # Errors
 ///
 /// - If the list of segments is empty, [`ArgumentError::Missing`] is returned.
 /// - If the segment cannot be parsed into an argument, [`ArgumentError::Argument`] is
 /// returned.
-pub async fn required_argument<T>(
+pub async fn required_argument_from_str<T>(
+    _ctx: &Context,
+    _msg: &Message,
+    segments: &mut ArgumentSegments<'_>,
+) -> Result<T, ArgumentError<T::Err>>
+where
+    T: std::str::FromStr,
+{
+    match segments.next() {
+        Some(seg) => T::from_str(seg).map_err(ArgumentError::Argument),
+        None => Err(ArgumentError::Missing),
+    }
+}
+
+/// Takes a single segment from a list of segments and parses an argument out of it using the
+/// [serenity::utils::Parse] trait.
+///
+/// # Errors
+///
+/// - If the list of segments is empty, [`ArgumentError::Missing`] is returned.
+/// - If the segment cannot be parsed into an argument, [`ArgumentError::Argument`] is
+/// returned.
+pub async fn required_argument_parse<T>(
     ctx: &Context,
     msg: &Message,
     segments: &mut ArgumentSegments<'_>,
@@ -60,13 +83,34 @@ where
 }
 
 /// Tries to take a single segment from a list of segments and parse
-/// an argument out of it.
+/// an argument out of it using the [std::str::FromStr] trait.
 ///
 /// If the list of segments is empty, `Ok(None)` is returned. Otherwise,
 /// the first segment is taken and parsed into an argument. If parsing succeeds,
 /// `Ok(Some(...))` is returned, otherwise `Err(...)`. The error is wrapped in
 /// [`ArgumentError::Argument`].
-pub async fn optional_argument<T>(
+pub async fn optional_argument_from_str<T>(
+    _ctx: &Context,
+    _msg: &Message,
+    segments: &mut ArgumentSegments<'_>,
+) -> Result<Option<T>, ArgumentError<T::Err>>
+where
+    T: std::str::FromStr,
+{
+    match segments.next() {
+        Some(seg) => T::from_str(seg).map(Some).map_err(ArgumentError::Argument),
+        None => Ok(None),
+    }
+}
+
+/// Tries to take a single segment from a list of segments and parse
+/// an argument out of it using the [serenity::utils::Parse] trait.
+///
+/// If the list of segments is empty, `Ok(None)` is returned. Otherwise,
+/// the first segment is taken and parsed into an argument. If parsing succeeds,
+/// `Ok(Some(...))` is returned, otherwise `Err(...)`. The error is wrapped in
+/// [`ArgumentError::Argument`].
+pub async fn optional_argument_parse<T>(
     ctx: &Context,
     msg: &Message,
     segments: &mut ArgumentSegments<'_>,
@@ -80,12 +124,28 @@ where
     }
 }
 
-/// Tries to parse many arguments from a list of segments.
+/// Tries to parse many arguments from a list of segments using the [std::str::FromStr] trait.
 ///
 /// Each segment in the list is parsed into a vector of arguments. If parsing
 /// all segments succeeds, the vector is returned. Otherwise, the first error
 /// is returned. The error is wrapped in [`ArgumentError::Argument`].
-pub async fn variadic_arguments<T>(
+pub async fn variadic_arguments_from_str<T>(
+    _ctx: &Context,
+    _msg: &Message,
+    segments: &mut ArgumentSegments<'_>,
+) -> Result<Vec<T>, ArgumentError<T::Err>>
+where
+    T: std::str::FromStr,
+{
+    segments.map(|seg| T::from_str(seg).map_err(ArgumentError::Argument)).collect()
+}
+
+/// Tries to parse many arguments from a list of segments using the [serenity::utils::Parse] trait.
+///
+/// Each segment in the list is parsed into a vector of arguments. If parsing
+/// all segments succeeds, the vector is returned. Otherwise, the first error
+/// is returned. The error is wrapped in [`ArgumentError::Argument`].
+pub async fn variadic_arguments_parse<T>(
     ctx: &Context,
     msg: &Message,
     segments: &mut ArgumentSegments<'_>,
@@ -98,13 +158,32 @@ where
         .map_err(ArgumentError::Argument)
 }
 
-/// Parses the remainder of the list of segments into an argument.
+/// Parses the remainder of the list of segments into an argument using the [std::str::FromStr]
+/// trait.
 ///
 /// All segments (even if none) are concatenated to a single string
 /// and parsed to the specified argument type. If parsing success,
 /// `Ok(...)` is returned, otherwise `Err(...)`. The error is wrapped in
 /// [`ArgumentError::Argument`].
-pub async fn rest_argument<T>(
+pub async fn rest_argument_from_str<T>(
+    _ctx: &Context,
+    _msg: &Message,
+    segments: &mut ArgumentSegments<'_>,
+) -> Result<T, ArgumentError<T::Err>>
+where
+    T: std::str::FromStr,
+{
+    T::from_str(segments.source()).map_err(ArgumentError::Argument)
+}
+
+/// Parses the remainder of the list of segments into an argument using the [serenity::utils::Parse]
+/// trait.
+///
+/// All segments (even if none) are concatenated to a single string
+/// and parsed to the specified argument type. If parsing success,
+/// `Ok(...)` is returned, otherwise `Err(...)`. The error is wrapped in
+/// [`ArgumentError::Argument`].
+pub async fn rest_argument_parse<T>(
     ctx: &Context,
     msg: &Message,
     segments: &mut ArgumentSegments<'_>,

--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -70,13 +70,13 @@ pub async fn optional_argument<T>(
     ctx: &Context,
     msg: &Message,
     segments: &mut ArgumentSegments<'_>,
-) -> Option<Result<T, ArgumentError<T::Err>>>
+) -> Result<Option<T>, ArgumentError<T::Err>>
 where
     T: serenity::utils::Parse,
 {
     match segments.next() {
-        Some(seg) => Some(T::parse(ctx, msg, seg).await.map_err(ArgumentError::Argument)),
-        None => None,
+        Some(seg) => T::parse(ctx, msg, seg).await.map(Some).map_err(ArgumentError::Argument)),
+        None => Ok(None),
     }
 }
 

--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -75,7 +75,7 @@ where
     T: serenity::utils::Parse,
 {
     match segments.next() {
-        Some(seg) => T::parse(ctx, msg, seg).await.map(Some).map_err(ArgumentError::Argument)),
+        Some(seg) => T::parse(ctx, msg, seg).await.map(Some).map_err(ArgumentError::Argument),
         None => Ok(None),
     }
 }

--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -12,7 +12,8 @@ use crate::utils::ArgumentSegments;
 pub enum ArgumentError<E> {
     /// Required argument is missing.
     ///
-    /// This is only returned by the [`required_argument`] function.
+    /// This is only returned by the [`required_argument_from_str`] and [`required_argument_parse`]
+    /// functions.
     Missing,
     /// Parsing the argument failed.
     ///


### PR DESCRIPTION
As part of #24, this draft pull request adds support for the Parse trait for parsing parameters, which will make it possible to use serenity model types like Member or Message as command parameters.

The Parse trait itself is a pending PR too (https://github.com/serenity-rs/serenity/pull/1235), hence this PR is a draft until the serenity Parse trait PR is done (or rejected...?).

I wasn't quite sure if the changes in the command_attr crate are acceptable as is, particularly the code around the msg ident.