### PR TITLE
Add `ParseEither` argument type

### DIFF
--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -257,9 +257,9 @@ where
 impl<T, U> fmt::Display for ParseEitherError<T, U>
 where
     T: Parse,
-    T::Err: fmt::Debug + fmt::Display,
+    T::Err: fmt::Display,
     U: Parse,
-    U::Err: fmt::Debug + fmt::Display,
+    U::Err: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(

--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -280,8 +280,8 @@ where
     type Err = ParseEitherError<T, U>;
 
     async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
-        let parse_one = async { T::parse(ctx, msg, s).await.map(|v| Self::VariantOne(v)) };
-        let parse_two = async { U::parse(ctx, msg, s).await.map(|v| Self::VariantTwo(v)) };
+        let parse_one = async { T::parse(ctx, msg, s).await.map(Self::VariantOne) };
+        let parse_two = async { U::parse(ctx, msg, s).await.map(Self::VariantTwo) };
 
         parse_one
             .or_else(|e1| async {

--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -205,7 +205,6 @@ where
 /// This can also be used to handle larger combinations of types by chaining [`ParseEither`]s,
 /// for example, `ParseEither<f32, ParseEither<i32, String>>`.
 #[derive(Debug)]
-#[non_exhaustive]
 pub enum ParseEither<T, U>
 where
     T: Parse,
@@ -218,7 +217,6 @@ where
 }
 
 /// Error that is returned when [`ParseEither::parse`] fails.
-#[non_exhaustive]
 pub struct ParseEitherError<T, U>
 where
     T: Parse,

--- a/framework/src/argument.rs
+++ b/framework/src/argument.rs
@@ -3,7 +3,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use serenity::{model::prelude::*, prelude::*};
+use serenity::{async_trait, futures::TryFutureExt, model::prelude::*, prelude::*, utils::Parse};
 
 use crate::utils::ArgumentSegments;
 
@@ -75,7 +75,7 @@ pub async fn required_argument_parse<T>(
     segments: &mut ArgumentSegments<'_>,
 ) -> Result<T, ArgumentError<T::Err>>
 where
-    T: serenity::utils::Parse,
+    T: Parse,
 {
     match segments.next() {
         Some(seg) => T::parse(ctx, msg, seg).await.map_err(ArgumentError::Argument),
@@ -117,7 +117,7 @@ pub async fn optional_argument_parse<T>(
     segments: &mut ArgumentSegments<'_>,
 ) -> Result<Option<T>, ArgumentError<T::Err>>
 where
-    T: serenity::utils::Parse,
+    T: Parse,
 {
     match segments.next() {
         Some(seg) => T::parse(ctx, msg, seg).await.map(Some).map_err(ArgumentError::Argument),
@@ -152,7 +152,7 @@ pub async fn variadic_arguments_parse<T>(
     segments: &mut ArgumentSegments<'_>,
 ) -> Result<Vec<T>, ArgumentError<T::Err>>
 where
-    T: serenity::utils::Parse,
+    T: Parse,
 {
     serenity::futures::future::try_join_all(segments.map(|seg| T::parse(ctx, msg, seg)))
         .await
@@ -190,7 +190,106 @@ pub async fn rest_argument_parse<T>(
     segments: &mut ArgumentSegments<'_>,
 ) -> Result<T, ArgumentError<T::Err>>
 where
-    T: serenity::utils::Parse,
+    T: Parse,
 {
     T::parse(ctx, msg, segments.source()).await.map_err(ArgumentError::Argument)
+}
+
+/// Denotes a type that can be either one of two different types.
+///
+/// It derives the [`Parse`] trait and can be used to parse an argument as either of two types.
+/// It attempts to parse into the type that is indicated first. If parsing into the first type fails,
+/// an attempt to parse into the second type is made. If both attempts fail, the overall parsing
+/// fails and returns a [`ParseEitherError`].
+///
+/// This can also be used to handle larger combinations of types by chaining [`ParseEither`]s,
+/// for example, `ParseEither<f32, ParseEither<i32, String>>`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ParseEither<T, U>
+where
+    T: Parse,
+    U: Parse,
+{
+    /// The first variant.
+    VariantOne(T),
+    /// The second variant.
+    VariantTwo(U),
+}
+
+/// Error that is returned when [`ParseEither::parse`] fails.
+#[non_exhaustive]
+pub struct ParseEitherError<T, U>
+where
+    T: Parse,
+    U: Parse,
+{
+    /// The error returned from parsing the first variant.
+    pub err_one: T::Err,
+    /// The error returned from parsing the second variant.
+    pub err_two: U::Err,
+}
+
+impl<T, U> fmt::Debug for ParseEitherError<T, U>
+where
+    T: Parse,
+    T::Err: fmt::Debug,
+    U: Parse,
+    U::Err: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ParseEitherError")
+            .field("err_one", &self.err_one)
+            .field("err_two", &self.err_two)
+            .finish()
+    }
+}
+
+impl<T, U> std::error::Error for ParseEitherError<T, U>
+where
+    T: Parse,
+    T::Err: fmt::Debug + fmt::Display,
+    U: Parse,
+    U::Err: fmt::Debug + fmt::Display,
+{
+}
+
+impl<T, U> fmt::Display for ParseEitherError<T, U>
+where
+    T: Parse,
+    T::Err: fmt::Debug + fmt::Display,
+    U: Parse,
+    U::Err: fmt::Debug + fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Parsing into type one failed: {}\nParsing into type two failed: {}",
+            self.err_one, self.err_two
+        )
+    }
+}
+
+#[async_trait]
+impl<T, U> Parse for ParseEither<T, U>
+where
+    T: Parse,
+    T::Err: Send,
+    U: Parse,
+{
+    type Err = ParseEitherError<T, U>;
+
+    async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
+        let parse_one = async { T::parse(ctx, msg, s).await.map(|v| Self::VariantOne(v)) };
+        let parse_two = async { U::parse(ctx, msg, s).await.map(|v| Self::VariantTwo(v)) };
+
+        parse_one
+            .or_else(|e1| async {
+                parse_two.await.map_err(|e2| Self::Err {
+                    err_one: e1,
+                    err_two: e2,
+                })
+            })
+            .await
+    }
 }

--- a/framework/src/parse.rs
+++ b/framework/src/parse.rs
@@ -21,7 +21,7 @@ use crate::utils::Segments;
 /// This can be expressed in a regular expression as `<@!?\d+>`.
 ///
 /// As an example, these are valid mentions:
-/// - <@110372470472613888>
+/// - \<@110372470472613888>
 /// - <@!110372470472613888>
 ///
 /// Returns the mention and the rest of the message after the mention, with trimmed


### PR DESCRIPTION
This PR adds a `ParseEither` argument type as described in #32.

I'm unsure about a few things:

- The `Debug` and `Display` requirement for the `Error` impl for `ParseEitherError`. I think both of those requirements are reasonable but am not sure if any other route is more preferable.
- The `Send` requirement for `T::Err` for the `Parse` impl for `ParseEither`. I don't see a way to remove that requirement.
